### PR TITLE
Email field

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ IconField
 If you'd like to render a field with an icon in it, you'll need to make use of the Crispy Forms layout object,
 and the `IconField` from our package. See below for an example:
 
-![IconField](https://i.imgur.com/dLs78nW.png)
+![IconField](https://i.imgur.com/tHsPHrM.png)
 
 ```python
 from crispy_forms.helper import FormHelper

--- a/README.md
+++ b/README.md
@@ -37,6 +37,58 @@ CRISPY_TEMPLATE_PACK = "bulma"
 
 You may also need to use Layout objects or form objects from `django_crispy_bulma` in order to build certain objects, like the UploadField. See the documentation below for specifics on objects like these.
 
+EmailField
+----------
+
+The EmailField looks like this:
+
+![EmailField](https://i.imgur.com/IBioO0Y.gif)
+
+An EmailField can be created simply, like any other field in your form. For example:
+
+```python
+from django.forms import Form
+from django_crispy_bulma.forms import EmailField
+
+class MyForm(Form):
+    my_email = EmailField(
+        label="email",
+        required=True
+    )
+```
+
+
+IconField
+---------
+
+If you'd like to render a field with an icon in it, you'll need to make use of the Crispy Forms layout object,
+and the `IconField` from our package. See below for an example:
+
+![IconField](https://i.imgur.com/dLs78nW.png)
+
+```python
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout
+from django.forms import Form, CharField
+
+from django_crispy_bulma.layout import IconField
+
+class SetupForm(Form):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper(self)
+
+        self.helper.layout = Layout(
+            IconField("username", icon_prepend="user", title="Username"),
+        )
+
+    username = CharField(
+        label="Username",
+        required=True,
+    )
+```
+
 UploadField
 -----------
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ class SetupForm(Form):
         self.helper = FormHelper(self)
 
         self.helper.layout = Layout(
-            IconField("username", icon_prepend="user", title="Username"),
+            IconField("username", icon_prepend="user"),
         )
 
     username = CharField(
@@ -88,6 +88,8 @@ class SetupForm(Form):
         required=True,
     )
 ```
+
+Note that `IconField` also supports an `icon_append` keyword argument. This field only supports font-awesome icons.
 
 UploadField
 -----------

--- a/django_crispy_bulma/forms.py
+++ b/django_crispy_bulma/forms.py
@@ -1,7 +1,12 @@
+from django.forms import EmailField as DjangoEmailField
 from django.forms import FileField as DjangoFileField
 from django.forms import ImageField as DjangoImageField
 
-from django_crispy_bulma.widgets import FileUploadInput
+from django_crispy_bulma.widgets import EmailInput, FileUploadInput
+
+
+class EmailField(DjangoEmailField):
+    widget = EmailInput()
 
 
 class ImageField(DjangoImageField):

--- a/django_crispy_bulma/templatetags/crispy_forms_bulma_field.py
+++ b/django_crispy_bulma/templatetags/crispy_forms_bulma_field.py
@@ -126,7 +126,7 @@ class CrispyBulmaFieldNode(template.Node):
 
             # HTML5 required attribute
             if html5_required and field.field.required and "required" not in widget.attrs:
-                if field.field.widget.__class__.__name__ is not "RadioSelect":
+                if field.field.widget.__class__.__name__ != "RadioSelect":
                     widget.attrs["required"] = "required"
 
             for attribute_name, attribute in attr.items():

--- a/django_crispy_bulma/widgets.py
+++ b/django_crispy_bulma/widgets.py
@@ -1,4 +1,26 @@
 from django.forms import ClearableFileInput
+from django.forms import EmailInput as DjangoEmailInput
+
+
+class EmailInput(DjangoEmailInput):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get_context(self, *args, **kwargs):
+        context = super().get_context(*args, **kwargs)
+        classes = context["widget"]["attrs"]["class"].split()
+
+        if "emailinput" in classes:
+            # Django includes this class; it's not the end of the world to keep it
+            # but we remove it to keep things clean and avoid accidental styling
+
+            classes.remove("emailinput")
+
+        # The correct class to use with Bulma is "input", so we just need to add it
+        classes.append("input")
+        context["widget"]["attrs"]["class"] = " ".join(classes)
+
+        return context
 
 
 class FileUploadInput(ClearableFileInput):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='django-crispy-bulma',
-    version='0.1.1',
+    version='0.1.2',
     description='Django application to add \'django-crispy-forms\' layout objects for Bulma.io',
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I noticed that Django was adding the wrong class to email input fields, so I worked with @heavysaturn over on Discord to find a solution.

---

* Adds an EmailField and EmailInput widget with the correct class handling
* Fixes a linting error in `django_crispy_bulma/templatetags/crispy_forms_bulma_field.py`, where a string was being compared with `is not` - probably an artifact of the original fork
* Bumps the version to `0.1.2`