### PR TITLE
Require only a minimum django-crispy-forms version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     install_requires=[
         'Django>=2.0',
-        'django-crispy-forms==1.7.2'
+        'django-crispy-forms>=1.7.2'
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
django-crispy-forms is a library, the requirements shoudn't be so strict.